### PR TITLE
프리티어 설정

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 120,
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "htmlWhitespaceSensitivity": "ignore"
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,22 +1,22 @@
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import './globals.css';
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-    title: "Women on the line",
-    description: "선 위의 여성들",
+    title: 'Women on the line',
+    description: '선 위의 여성들',
 };
 
 export default function RootLayout({
-  children,
+    children,
 }: Readonly<{
-  children: React.ReactNode;
+    children: React.ReactNode;
 }>) {
-  return (
-    <html lang="en">
-      <body className={inter.className}>{children}</body>
-    </html>
-  );
+    return (
+        <html lang="en">
+            <body className={inter.className}>{children}</body>
+        </html>
+    );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
-import Image from "next/image";
+import Image from 'next/image';
 
-const ArtworkImage = ({ className, src }: { className: string, src: string }) => (
-    <div className={ `relative ${ className }` }>
-        <Image className="object-contain" src={ `/images/sources/${ src }` } alt="" fill/>
+const ArtworkImage = ({ className, src }: { className: string; src: string }) => (
+    <div className={`relative ${className}`}>
+        <Image className="object-contain" src={`/images/sources/${src}`} alt="" fill />
     </div>
 );
 
@@ -11,34 +11,52 @@ export default function Home() {
         <main>
             <section className="relative h-screen">
                 <section className="grid grid-cols-3 grid-rows-3 w-full h-full absolute">
-                    <ArtworkImage className="col-start-1 col-span-1 row-start-1 row-span-1 scale-150 -translate-y-2/3"
-                                  src="mix_brush.png"/>
+                    <ArtworkImage
+                        className="col-start-1 col-span-1 row-start-1 row-span-1 scale-150 -translate-y-2/3"
+                        src="mix_brush.png"
+                    />
                     <ArtworkImage
                         className="col-start-3 col-span-1 row-start-1 row-span-1 scale-150 translate-x-1/4 -translate-y-1/3"
-                        src="blue_brush_3.png"/>
-                    <ArtworkImage className="col-start-1 col-span-1 row-start-2 row-span-1 scale-150 -translate-x-1/3"
-                                  src="blue_brush.png"/>
-                    <ArtworkImage className="col-start-3 col-span-1 row-start-2 row-span-1 scale-150 translate-y-1/4"
-                                  src="green_brush.png"/>
+                        src="blue_brush_3.png"
+                    />
+                    <ArtworkImage
+                        className="col-start-1 col-span-1 row-start-2 row-span-1 scale-150 -translate-x-1/3"
+                        src="blue_brush.png"
+                    />
+                    <ArtworkImage
+                        className="col-start-3 col-span-1 row-start-2 row-span-1 scale-150 translate-y-1/4"
+                        src="green_brush.png"
+                    />
                     <ArtworkImage
                         className="col-start-1 col-span-1 row-start-3 row-span-1 scale-150 -translate-x-2/3 translate-y-2/3"
-                        src="pink_brush.png"/>
+                        src="pink_brush.png"
+                    />
                     <ArtworkImage
                         className="col-start-2 col-span-1 row-start-3 row-span-1 scale-150 -translate-x-1/2 translate-y-1/4"
-                        src="yellow_brush.png"/>
+                        src="yellow_brush.png"
+                    />
                     <ArtworkImage
                         className="col-start-3 col-span-1 row-start-3 row-span-1 scale-150 translate-x-1/2 translate-y-1/4"
-                        src="blue_brush_2.png"/>
+                        src="blue_brush_2.png"
+                    />
                 </section>
                 <section className="grid grid-cols-3 grid-rows-3 w-full h-full absolute">
-                    <ArtworkImage className="col-start-1 col-span-2 row-start-1 row-span-2 scale-150 -translate-y-1/4"
-                                  src="line_1.png"/>
-                    <ArtworkImage className="col-start-3 col-span-1 row-start-1 row-span-2 scale-150 translate-x-1/2"
-                                  src="line_2.png"/>
-                    <ArtworkImage className="col-start-1 col-span-1 row-start-3 row-span-1 scale-150 -translate-x-1/2"
-                                  src="line_3.png"/>
-                    <ArtworkImage className="col-start-2 col-span-3 row-start-3 row-span-1 scale-150 translate-y-1/3"
-                                  src="line_4.png"/>
+                    <ArtworkImage
+                        className="col-start-1 col-span-2 row-start-1 row-span-2 scale-150 -translate-y-1/4"
+                        src="line_1.png"
+                    />
+                    <ArtworkImage
+                        className="col-start-3 col-span-1 row-start-1 row-span-2 scale-150 translate-x-1/2"
+                        src="line_2.png"
+                    />
+                    <ArtworkImage
+                        className="col-start-1 col-span-1 row-start-3 row-span-1 scale-150 -translate-x-1/2"
+                        src="line_3.png"
+                    />
+                    <ArtworkImage
+                        className="col-start-2 col-span-3 row-start-3 row-span-1 scale-150 translate-y-1/3"
+                        src="line_4.png"
+                    />
                 </section>
             </section>
         </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint": "^8",
         "eslint-config-next": "14.1.0",
         "postcss": "^8",
+        "prettier": "^3.2.5",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
       }
@@ -3666,6 +3667,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
     "postcss": "^8",
+    "prettier": "^3.2.5",
     "tailwindcss": "^3.3.0",
     "eslint": "^8",
     "eslint-config-next": "14.1.0"


### PR DESCRIPTION
### 작업 내용
- 일관된 코드 포맷팅을 위한 프리티어 설정
- 기존 코드에 포맷팅 적용

### 설정 세부 내용
```json
{
  "trailingComma": "es5", // es5 기준으로 후행 쉼표 적용
  "tabWidth": 4, // 들여쓰기를 크게 해서 읽기에 적당한 구조까지만 html element를 작성하도록 의도
  "semi": true, // 세미콜론 적용
  "singleQuote": true, // html attributes("")와의 구분
  "printWidth": 120, // 가능한 코드 길이
  "bracketSpacing": true, // 객체 bracket 공백
  "bracketSameLine": false, // 닫는 braket (ex_`/>` 줄바꿈 처리)
  "htmlWhitespaceSensitivity": "ignore" // 일관된 코드 스타일을 위해 ignore(display: block case 처럼 포맷팀됨) 사용 
}
```
####  "arrowParens": "always" 옵션
> https://prettier.io/docs/en/options.html#arrow-function-parentheses
- prettier 2.0.0 버전부터는 "always"가 기본값으로 변경되어 따로 설정하지 않음
- "avoId"로 설정하면 파라미터가 하나일 때 간결해보일 수 있음 
- 그러나 typescript에서는 type 입력을 위해 괄호가 필요하므로 쉬운 type 입력을 위해 "always" 사용
> <img width="548" alt="image" src="https://github.com/jayjeong8/women-on-the-line/assets/82160479/b8523b23-db14-4aa1-aaca-e97bf911b838">
